### PR TITLE
Collect map of decoded Go values

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -20,6 +20,7 @@ type decoder struct {
 	errs      DecodeErrors
 	dm        dataMap
 	values    url.Values
+	goValues  map[string]interface{}
 	maxKeyLen int
 	namespace []byte
 }
@@ -170,6 +171,9 @@ func (d *decoder) traverseStruct(v reflect.Value, typ reflect.Type, namespace []
 		}
 
 		if d.setFieldByType(v.Field(f.idx), namespace, 0) {
+			if d.goValues != nil {
+				d.goValues[f.name] = v.Field(f.idx).Interface()
+			}
 			set = true
 		}
 	}

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1615,3 +1615,26 @@ func TestDecodeArrayBug(t *testing.T) {
 	Equal(t, data.G[1], "")
 	Equal(t, data.G[2], "20")
 }
+
+func TestDecodeWithGoValuesCollection(t *testing.T) {
+	type EmbeddedName struct {
+		Name string `form:"name"`
+	}
+	var data struct {
+		EmbeddedName
+		Age int `form:"age"`
+	}
+	decoder := NewDecoder()
+	goValues := make(map[string]interface{})
+	err := decoder.Decode(&data, url.Values{
+		"name": {"John"},
+		"age":  {"30"},
+	}, goValues)
+	Equal(t, err, nil)
+	Equal(t, data.Name, "John")
+	Equal(t, data.Age, 30)
+	Equal(t, goValues, map[string]interface{}{
+		"name": "John",
+		"age":  30,
+	})
+}

--- a/form_decoder.go
+++ b/form_decoder.go
@@ -142,7 +142,7 @@ func (d *Decoder) RegisterCustomTypeFunc(fn DecodeCustomTypeFunc, types ...inter
 // Decode parses the given values and sets the corresponding struct and/or type values
 //
 // Decode returns an InvalidDecoderError if interface passed is invalid.
-func (d *Decoder) Decode(v interface{}, values url.Values) (err error) {
+func (d *Decoder) Decode(v interface{}, values url.Values, collectGoValues ...map[string]interface{}) (err error) {
 
 	val := reflect.ValueOf(v)
 
@@ -158,6 +158,9 @@ func (d *Decoder) Decode(v interface{}, values url.Values) (err error) {
 	typ := val.Type()
 
 	if val.Kind() == reflect.Struct && typ != timeType {
+		if len(collectGoValues) > 0 {
+			dec.goValues = collectGoValues[0]
+		}
 		dec.traverseStruct(val, typ, dec.namespace[0:0])
 	} else {
 		dec.setFieldByType(val, dec.namespace[0:0], 0)


### PR DESCRIPTION
I want to use `github.com/go-playground/form` together with JSON Schema validation.
JSON Schema validator expects to receive decoded field values.

Every decoded value needed to be accessed by form name.

In order to avoid additional reflection traversal, those decoded values can be collected during form decode/mapping into a `map[string]interface{}`.

To avoid breaking change of API collection control is added as optional variadic argument.